### PR TITLE
migrate to support CDK v2

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,10 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import yaml
-from aws_cdk import core
+
+from constructs import Construct
+from aws_cdk import App, Stack, Environment                   # core constructs
+
 from pipeline import PipelineCDKStack
 
-app = core.App()
+app = App()
 
 # Get target stage from cdk context
 config_file = app.node.try_get_context('config')
@@ -21,7 +24,8 @@ else:
 with open(configFilePath, 'r', encoding="utf-8") as f:
     config = yaml.load(f, Loader=yaml.SafeLoader)
 
-env = core.Environment(region=config["awsAccount"]["awsRegion"])
+
+env = Environment(region=config["awsAccount"]["awsRegion"])
 
 # Initiating the CodePipeline stack
 PipelineCDKStack(

--- a/cdk.json
+++ b/cdk.json
@@ -28,12 +28,9 @@
       "aws",
       "aws-cn"
     ],
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
     "aws-cdk:enableDiffNoFail": "true",
     "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
     "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
     "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
     "@aws-cdk/aws-efs:defaultEncryptionAtRest": true
   }

--- a/pipeline.py
+++ b/pipeline.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Dict
+from constructs import Construct
+from aws_cdk import Stack
 from aws_cdk import (
-    core,
     aws_codecommit as codecommit,
     aws_iam as iam
 )
@@ -16,7 +17,7 @@ from etl.infrastructure import CdkGlueBlogStage
 from helper import create_archive
 
 
-class PipelineCDKStack(core.Stack):
+class PipelineCDKStack(Stack):
 
     def create_pipeline(self, config):
         # Archive need to be created since there's an issue with creating assets for codecommit
@@ -99,7 +100,7 @@ class PipelineCDKStack(core.Stack):
         pipeline.add_stage(CdkGlueBlogStage(self, 'CdkGlueStage', config=config))
         pipeline.node.add_dependency(codecommit_repo)
 
-    def __init__(self, scope: core.Construct, construct_id: str, config: Dict, **kwargs) -> None:
+    def __init__(self, scope: Construct, construct_id: str, config: Dict, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
         self.create_pipeline(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-aws-cdk.core==1.169.0
-aws-cdk.aws_glue==1.169.0
-aws-cdk.pipelines==1.169.0
-aws_cdk.aws_s3_deployment==1.169.0
+aws-cdk-lib
+constructs
+aws-cdk.aws_glue_alpha
 pyyaml==5.4
+
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setuptools.setup(
     package_dir={"": "cdkglueblog"},
     packages=setuptools.find_packages(where="cdkglueblog"),
     install_requires=[
-        "aws-cdk.core==1.104.0"
+        "aws-cdk-lib>=2.0.0",
+        "constructs>=10.0.0",
     ],
     python_requires=">=3.8",
     classifiers=[


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* It's a great tutorial for user to ramp up with AWS Glue and DevOps pipeline, and I recommend to migrate to CDK v2 since new features will be only support v2 and v1 is gradually deprecating. 

Quote from official document: _"The older CDK v1 entered maintenance on June 1, 2022 and will now receive only critical bug fixes and security patches. New features will be developed for CDK v2 exclusively. Support for CDK v1 will end entirely on June 1, 2023."_


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
